### PR TITLE
fix: remove adw.banner

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -72,3 +72,7 @@ jobs:
         with:
           verbose: true
           print-hash: true
+
+      - uses: ncipollo/release-action@v1
+        with:
+          body: See [CHANGELOG.md](https://github.com/dynobo/keyhint/blob/main/CHANGELOG.md] for details.

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -75,4 +75,4 @@ jobs:
 
       - uses: ncipollo/release-action@v1
         with:
-          body: See [CHANGELOG.md](https://github.com/dynobo/keyhint/blob/main/CHANGELOG.md] for details.
+          body: See [CHANGELOG.md](https://github.com/dynobo/keyhint/blob/main/CHANGELOG.md) for details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## v0.5.0
+## v0.5.1 (2024-07-04)
+
+- Fix support for older version of `libadwaita`.
+- Add cheatsheet for GH copilot
+
+## v0.5.0 (2024-04-23)
 
 - Breaking changes:
   - Renamed the attribute `regex_process` in `toml`-files to `regex_wmclass`.

--- a/keyhint/config/gh-copilot.toml
+++ b/keyhint/config/gh-copilot.toml
@@ -1,0 +1,22 @@
+id = "gh-copilot"
+url = "https://docs.github.com/en/copilot/configuring-github-copilot/configuring-github-copilot-in-your-environment"
+hidden = true
+
+[match]
+regex_wmclass = "^$"
+regex_title = "^$"
+
+[section]
+
+[section.Suggestions]
+"Tab" = "Accept all"
+"Ctrl + r Right" = "Accept next word"
+"Alt + ] / [ " = "Show next / previous"
+"Alt + \\" = "Trigger suggestion"
+"Ctrl + Enter" = "Open 10 suggestions"
+"Esc" = "Dismiss"
+
+[section.Chat]
+"Ctrl + i" = "Open inline chat"
+"@" = "Add 'participants'"
+"#" = "Add context"

--- a/keyhint/context.py
+++ b/keyhint/context.py
@@ -41,9 +41,9 @@ def get_gnome_version() -> str:
         return "(n/a)"
 
     try:
-        output = subprocess.check_output(
+        output = subprocess.check_output(  # noqa: S603
             ["gnome-shell", "--version"],  # noqa: S607
-            shell=False,  # noqa: S603
+            shell=False,
             text=True,
         )
         if result := re.search(r"\s+([\d\.]+)", output.strip()):
@@ -70,9 +70,9 @@ def get_kde_version() -> str:
         return "(n/a)"
 
     try:
-        output = subprocess.check_output(
+        output = subprocess.check_output(  # noqa: S603
             ["plasmashell", "--version"],  # noqa: S607
-            shell=False,  # noqa: S603
+            shell=False,
             text=True,
         )
         if result := re.search(r"([\d+\.]+)", output.strip()):
@@ -216,9 +216,9 @@ def get_active_window_via_kwin() -> tuple[str, str]:
     # The output has to be read through journalctl instead. A timestamp for
     # filtering speeds up the process.
     log_lines = (
-        subprocess.check_output(
+        subprocess.check_output(  # noqa: S602
             f'journalctl --user -o cat --since "{since}"',
-            shell=True,  # noqa: S602
+            shell=True,
         )
         .decode()
         .split("\n")
@@ -243,9 +243,9 @@ def get_active_window_via_xprop() -> tuple[str, str]:
         Tuple(str, str): window class, window title
     """
     # Query id of active window
-    stdout_bytes: bytes = subprocess.check_output(
+    stdout_bytes: bytes = subprocess.check_output(  # noqa: S602
         "xprop -root _NET_ACTIVE_WINDOW",  # noqa: S607
-        shell=True,  # noqa: S602
+        shell=True,
     )
     stdout = stdout_bytes.decode()
 
@@ -257,9 +257,9 @@ def get_active_window_via_xprop() -> tuple[str, str]:
     window_id: str = match.group(1)
 
     # Query app_title and app_process
-    stdout_bytes = subprocess.check_output(
+    stdout_bytes = subprocess.check_output(  # noqa: S602
         f"xprop -id {window_id} WM_NAME WM_CLASS",
-        shell=True,  # noqa: S602
+        shell=True,
     )
     stdout = stdout_bytes.decode()
 

--- a/keyhint/resources/style.css
+++ b/keyhint/resources/style.css
@@ -2,6 +2,7 @@
 @define-color borders_color rgba(0,0,0,0.5);
 @define-color shadow_color rgba(0,0,0,0.3);
 @define-color accent_color #FF2E88;
+@define-color banner_bg_color rgba(42, 123, 222, 0.3);
 
 .keycap {
   min-width: 15px;
@@ -40,4 +41,9 @@
 .bindings-section,
 .bindings-section .view {
   background-color: transparent;
+}
+
+.banner {
+  background-color: @banner_bg_color;
+  font-weight: bold;
 }

--- a/keyhint/resources/window.ui
+++ b/keyhint/resources/window.ui
@@ -14,18 +14,54 @@
           <object class="GtkBox" id="container">
             <property name="orientation">1</property>
             <child>
-              <object class="AdwBanner" id="banner_window_calls">
-                <property name="button-label" translatable="true">Gnome Extension Webpage</property>
-                <property name="title" translatable="true">The Gnome Extension 'Window Calls' is required on Wayland!</property>
-                <property name="revealed">False</property>
-                <property name="action-name">win.visit_window_calls</property>
+              <object class="GtkRevealer" id="banner_window_calls">
+                <style>
+                  <class name="banner" />
+                </style>
+                <child>
+                  <object class="GtkBox">
+                    <property name="halign">center</property>
+                    <property name="margin-bottom">10</property>
+                    <property name="margin-end">5</property>
+                    <property name="margin-start">5</property>
+                    <property name="margin-top">10</property>
+                    <property name="orientation">horizontal</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="label">The Gnome Extension 'Window Calls' is required on Wayland!</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton">
+                        <property name="margin-start">15</property>
+                        <property name="label">Gnome Extension Webpage</property>
+                        <property name="action-name">win.visit_window_calls</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
               </object>
             </child>
             <child>
-              <object class="AdwBanner" id="banner_xprop">
-                <property name="title" translatable="true">The tool 'xprop' is required on Xorg. Install the system package 'x11-utils' (Debian/Ubuntu) or 'xprop' (Arch/Fedora)!</property>
-                <property name="revealed">False</property>
-                <property name="action-name">win.visit_xprop</property>
+              <object class="GtkRevealer" id="banner_xprop">
+                <style>
+                  <class name="banner" />
+                </style>
+                <child>
+                  <object class="GtkBox">
+                    <property name="margin-bottom">10</property>
+                    <property name="margin-end">5</property>
+                    <property name="margin-start">5</property>
+                    <property name="margin-top">10</property>
+                    <property name="orientation">horizontal</property>
+                    <property name="halign">center</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="label">The tool 'xprop' is required on Xorg! Install the system package 'x11-utils' (Debian/Ubuntu) or 'xprop' (Arch/Fedora)!</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
               </object>
             </child>
             <child>

--- a/keyhint/window.py
+++ b/keyhint/window.py
@@ -58,8 +58,8 @@ class KeyhintWindow(Gtk.ApplicationWindow):
     __gtype_name__ = "main_window"
 
     overlay = cast(Adw.ToastOverlay, Gtk.Template.Child())
-    banner_window_calls = cast(Adw.Banner, Gtk.Template.Child())
-    banner_xprop = cast(Adw.Banner, Gtk.Template.Child())
+    banner_window_calls = cast(Gtk.Revealer, Gtk.Template.Child())
+    banner_xprop = cast(Gtk.Revealer, Gtk.Template.Child())
     scrolled_window = cast(Gtk.ScrolledWindow, Gtk.Template.Child())
     container = cast(Gtk.Box, Gtk.Template.Child())
     sheet_container_box = cast(Gtk.FlowBox, Gtk.Template.Child())
@@ -130,7 +130,7 @@ class KeyhintWindow(Gtk.ApplicationWindow):
                 if context.has_window_calls_extension():
                     wm_class, wm_title = context.get_active_window_via_window_calls()
                 else:
-                    self.banner_window_calls.set_revealed(True)
+                    self.banner_window_calls.set_reveal_child(True)
                     logger.error("Window Calls extension not found!")
             case True, "kde":
                 wm_class, wm_title = context.get_active_window_via_kwin()
@@ -138,7 +138,7 @@ class KeyhintWindow(Gtk.ApplicationWindow):
                 if context.has_xprop():
                     wm_class, wm_title = context.get_active_window_via_xprop()
                 else:
-                    self.banner_xprop.set_revealed(True)
+                    self.banner_xprop.set_reveal_child(True)
                     logger.error("xprop not found!")
 
         logger.debug("Detected wm_class: '%s'.", wm_class)

--- a/keyhint/window.py
+++ b/keyhint/window.py
@@ -339,6 +339,15 @@ class KeyhintWindow(Gtk.ApplicationWindow):
         for sheet_id in sorted([s["id"] for s in self.sheets]):
             model.append(sheet_id)
 
+    @property
+    def active_headerbar(self) -> headerbar.HeaderBarBox:
+        """Return the currently active headerbar depending on window state."""
+        return (
+            self.headerbars.fullscreen
+            if self.is_fullscreen()
+            else self.headerbars.normal
+        )
+
     @check_state
     def on_set_fallback_sheet(
         self, action: Gio.SimpleAction, state: GLib.Variant
@@ -458,12 +467,8 @@ class KeyhintWindow(Gtk.ApplicationWindow):
 
     def focus_search_entry(self) -> None:
         """Focus search entry of the active headerbar."""
-        if self.is_fullscreen():
-            self.headerbars.fullscreen.search_entry.grab_focus()
-            self.headerbars.fullscreen.search_entry.set_position(-1)
-        else:
-            self.headerbars.normal.search_entry.grab_focus()
-            self.headerbars.normal.search_entry.set_position(-1)
+        self.active_headerbar.search_entry.grab_focus()
+        self.active_headerbar.search_entry.set_position(-1)
 
     def show_create_new_sheet_toast(self) -> None:
         """Display a toast notification to offer the creation of a new cheatsheet."""
@@ -523,15 +528,9 @@ class KeyhintWindow(Gtk.ApplicationWindow):
             case Gdk.KEY_F11, _:
                 self.activate_action("win.fullscreen")
             case Gdk.KEY_f, True:
-                if self.is_fullscreen():
-                    self.headerbars.fullscreen.search_entry.grab_focus()
-                else:
-                    self.headerbars.normal.search_entry.grab_focus()
+                self.active_headerbar.grab_focus()
             case Gdk.KEY_s, True:
-                if self.is_fullscreen():
-                    self.headerbars.fullscreen.sheet_dropdown.grab_focus()
-                else:
-                    self.headerbars.normal.sheet_dropdown.grab_focus()
+                self.active_headerbar.sheet_dropdown.grab_focus()
             case (Gdk.KEY_Up, _) | (Gdk.KEY_k, True):
                 self.scroll(to_start=True, by_page=False)
             case (Gdk.KEY_Down, _) | (Gdk.KEY_j, True):


### PR DESCRIPTION
This widget is unsupported by the libwaita version shipped with Ubuntu
22.04.